### PR TITLE
Load Data, VIT/SoC 분리 코드 작성

### DIFF
--- a/Linear Regression/LR.ipynb
+++ b/Linear Regression/LR.ipynb
@@ -9,12 +9,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "vscode": {
-     "languageId": "plaintext"
-    }
-   },
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -23,7 +19,7 @@
     "import tensorflow as tf\n",
     "import keras\n",
     "import os\n",
-    "import glob\n",
+    "import glob21\n",
     "import seaborn as sns\n",
     "from mpl_toolkits.mplot3d import Axes3D\n",
     "import math\n",
@@ -31,7 +27,7 @@
     "import tensorflow as tf\n",
     "from sklearn.preprocessing import MinMaxScaler\n",
     "from sklearn.metrics import mean_squared_error, mean_absolute_error\n",
-    "from keras.preprocessing.sequence import TimeseriesGenerator\n",
+    "from keras_preprocessing.sequence import TimeseriesGenerator\n",
     "from keras.models import Sequential\n",
     "from keras.layers import Dense, LSTM, SimpleRNN, Dropout\n",
     "from keras.optimizers import RMSprop\n",
@@ -39,11 +35,111 @@
     "from keras.models import model_from_json\n",
     "from keras import optimizers"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. Load data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "csv_DST_007 생성 완료\n",
+      "csv_DST_008 생성 완료\n",
+      "csv_FUDS_007 생성 완료\n",
+      "csv_FUDS_008 생성 완료\n",
+      "csv_US06_007 생성 완료\n",
+      "csv_US06_008 생성 완료\n",
+      "      Current(A)  Voltage(V)  Temperature (C)_1        SoC\n",
+      "0       0.000191    3.526907          -8.332584  80.000000\n",
+      "1       0.000191    3.526599          -8.565621  80.000000\n",
+      "2       0.000191    3.526291          -8.332584  80.000000\n",
+      "3       0.000003    3.525676          -8.332584  80.000000\n",
+      "4       0.000378    3.525984          -8.332584  80.000000\n",
+      "...          ...         ...                ...        ...\n",
+      "5279   -0.480845    2.945211          -7.249700   0.356594\n",
+      "5280   -3.849219    2.086517          -7.094693   0.275559\n",
+      "5281   -3.849219    2.045275          -7.094693   0.176988\n",
+      "5282   -3.849219    2.017267          -6.985489   0.079046\n",
+      "5283   -3.849219    1.999724          -7.094693   0.000000\n",
+      "\n",
+      "[5284 rows x 4 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 온도 선택 [N10, 0, 10, 20, 25, 30, 40, 50]\n",
+    "# temp 변수에 설정\n",
+    "temp = 'N10'\n",
+    "mode = ['DST', 'FUDS' ,'US06']\n",
+    "current_dir = os.getcwd()\n",
+    "parent_dir = os.path.abspath(os.path.join(current_dir, os.pardir))\n",
+    "\n",
+    "for m in mode:\n",
+    "    data_dir = os.path.join(parent_dir, f'DB Preprocessing/refined_data/{temp}/{m}')\n",
+    "    file_names = os.listdir(data_dir)\n",
+    "    for file_name in file_names:\n",
+    "        csv_dir = os.path.join(data_dir, file_name)\n",
+    "        if '007' in file_name:\n",
+    "            num = '007'\n",
+    "        else: \n",
+    "            num = '008'\n",
+    "        globals()['csv_{}'.format(f'{m}_{num}')] = pd.DataFrame(pd.read_csv(csv_dir))\n",
+    "        print(f'csv_{m}_{num} 생성 완료')\n",
+    "print(csv_DST_007)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. V, I, T / SoC 분리 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num = ['007','008']\n",
+    "for m in mode:\n",
+    "    for n in num:\n",
+    "        var_name = f'csv_{m}_{n}'\n",
+    "        csv = globals()[var_name]\n",
+    "        globals()[f'input_{m}_{n}'] = csv[['Current(A)', 'Voltage(V)', 'Temperature (C)_1']]\n",
+    "        globals()[f'output_{m}_{n}'] = csv[['SoC']]\n",
+    "print(input_DST_007)\n",
+    "print(output_DST_007)\n",
+    "    "
+   ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Linear_regression 폴더에 ipynb 파일로 구현해두었습니다.
input_DST_007
input_DST_008
input_US06_007
output_US06_007 이런 식으로 만들어지며
input이 붙은 건 V,I,T 테이블이고
output이 붙은 건 SoC 테이블입니다.
LSTM 구현 시 그냥 가져다 쓰시면 될 것 같습니다.